### PR TITLE
Don't refer to biblionumber as Item Number

### DIFF
--- a/Koha/ILLRequest/Status.pm
+++ b/Koha/ILLRequest/Status.pm
@@ -112,7 +112,7 @@ sub getFullStatus {
 
     my $return = {
         id              => [ "Request Number", $self->{id} ],
-        biblionumber    => [ "Item Number", $self->{biblionumber} ],
+        biblionumber    => [ "Biblio Number", $self->{biblionumber} ],
         status          => [ "Status", $self->{status} ],
         placement_date  => [ "Placement Date", $self->{placement_date} ],
         reply_date      => [ "Response Date", $self->{reply_date} ],
@@ -139,7 +139,7 @@ sub getSummary {
     my ( $self, $params ) = @_;
     my $return = {
         id             => [ "Request Number", $self->{id} ],
-        biblionumber   => [ "Item Number", $self->{biblionumber} ],
+        biblionumber   => [ "Biblio Number", $self->{biblionumber} ],
         status         => [ "Status", $self->{status} ],
         reqtype        => [ "Request Type", $self->{reqtype} ],
     };

--- a/koha-tmpl/intranet-tmpl/prog/en/js/pages/ill.js
+++ b/koha-tmpl/intranet-tmpl/prog/en/js/pages/ill.js
@@ -77,7 +77,7 @@
                     request = currResult;
                     // This is currently part of an elaborate mock up.
                     // remove once api is working
-                    request['biblionumber'] = [ "Item Number", "" ];
+                    request['biblionumber'] = [ "Biblio Number", "" ];
                     request['borrowernumber'] = [ "Borrower Number", "" ];
                     request['status'] = [ "Status", "new" ];
                     request['reqtype'] = [ "Request Type", "book" ];


### PR DESCRIPTION
There are three places where a biblionumber is given the heading
"Item Number", which is confusing. This patch replaces "Item
Number" with "Biblio Number". This is still in violation of Koha
coding guideline "HTML4", which says that only first letters
should be uppercase:
http://wiki.koha-community.org/wiki/Coding_Guidelines#HTML4:_Upper_and_lower_cases_in_strings
But changing all the strings is something of a big task, so this
patch chooses to reduce confusion while being consistent with
the rest of the ILL work.