### PR TITLE
Let Koha::ILLRequest::Status::new accept a biblionumber

### DIFF
--- a/Koha/ILLRequest/Status.pm
+++ b/Koha/ILLRequest/Status.pm
@@ -58,7 +58,7 @@ sub new {
     my $self = {
         borrower        => $opts->{borrower} || '',
         borrowernumber  => $brwNum || 0,
-        biblionumber    => 0,
+        biblionumber    => $opts->{biblionumber} || '',
         status          => $status,
         placement_date  => DateTime->now,
         ts              => DateTime->now,


### PR DESCRIPTION
Currently, Koha::ILLRequest::Status::new is hardcoded with
biblionumber = 0. NNCIPP needs to record ILL requests against
local biblionumbers, so it would be nice if
Koha::ILLRequest::Status::new could accept them.