### PR TITLE
Fix qw() in list context

### DIFF
--- a/ill/ill-new.pl
+++ b/ill/ill-new.pl
@@ -85,7 +85,7 @@ if ( $input->param('query_type') eq 'manual' ) {
     my $nav_qry = "?query_type=search_cont&query_value=" . uri_escape($query);
     $nav_qry .= "&brw=" . $brw->borrowernumber;
     $nav_qry .= "&branch=" . $input->param('branch');
-    for my $opt qw( isbn issn title author type start_rec max_results ) {
+    for my $opt (qw( isbn issn title author type start_rec max_results )) {
         my $val = $input->param($opt);
         if ( $val ne '' ) {
             $opts->{$opt} = $val;


### PR DESCRIPTION
On Perl 5.18.2 I get this error:

syntax error at /home/magnus/scripts/kohaclone/ill/ill-new.pl line
88, near "$opt qw( isbn issn title author type start_rec max_results )"

The problem seems to be missing parens around the qw(), see e.g.:
http://blogs.perl.org/users/rurban/2010/09/qw-in-list-context-deprecated.html